### PR TITLE
Kuinの仕様変更により動作しなくなっていたので、修正を行いました

### DIFF
--- a/src/json.kn
+++ b/src/json.kn
@@ -11,19 +11,19 @@
 
 
 ; 入力された値の形式が不正
-+const himeJsonInvalidDataFmt: int :: 16#00001001
++const himeJsonInvalidDataFmt: int :: 0x00001001
 
 ; 文字列に制御文字が使われている場合に発生
-+const himeJsonControlCharacterExists: int :: 16#00001002
++const himeJsonControlCharacterExists: int :: 0x00001002
 
 ; 要素がカンマで区切られていない場合に発生
-+const himeJsonNoComma: int :: 16#00001003
++const himeJsonNoComma: int :: 0x00001003
 
 ; オブジェクト要素で同じキーがすでに存在している
-+const himeJsonSameKeyExists: int :: 16#00001004
++const himeJsonSameKeyExists: int :: 0x00001004
 
 ; true, false, null以外の単語が入力された
-+const himeJsonInvalidWord: int :: 16#00001005
++const himeJsonInvalidWord: int :: 0x00001005
 
 
 ; エラーメッセージ

--- a/src/json.kn
+++ b/src/json.kn
@@ -146,27 +146,27 @@ end enum
 	end func
 	
 	
-	+func toInt(value: &int): bool
-		ret false
+	+func toInt(existed: &bool): int
+		do existed :: false
+		ret 0
 	end func
 	
 	
 	+func toi(): int
-		var value: int
-		do me.toInt(&value)
-		ret value
+		var existed: bool
+		ret me.toInt(&existed)
 	end func
 	
 	
-	+func toFloat(value: &float): bool
-		ret false
+	+func toFloat(existed: &bool): float
+		do existed :: false
+		ret 0.0
 	end func
 	
 	
 	+func tof(): float
-		var value: float
-		do me.toFloat(&value)
-		ret value
+		var existed: bool
+		ret me.toFloat(&existed)
 	end func
 	
 	
@@ -236,15 +236,15 @@ end class
 	end func
 	
 	
-	+*func toInt(value: &int): bool
-		do value :: me.value ?(1, 0)
-		ret true
+	+*func toInt(existed: &bool): int
+		do existed :: true
+		ret me.value ?(1, 0)
 	end func
 	
 	
-	+*func toFloat(value: &float): bool
-		do value :: me.value ?(1.0, 0.0)
-		ret true
+	+*func toFloat(existed: &bool): float
+		do existed :: true
+		ret me.value ?(1.0, 0.0)
 	end func
 	
 	
@@ -274,15 +274,15 @@ end class
 	end func
 	
 	
-	+*func toInt(value: &int): bool
-		do value :: me.value$int
-		ret true
+	+*func toInt(existed: &bool): int
+		do existed :: true
+		ret me.value$int
 	end func
 	
 	
-	+*func toFloat(value: &float): bool
-		do value :: me.value
-		ret true
+	+*func toFloat(existed: &bool): float
+		do existed :: true
+		ret me.value
 	end func
 	
 	
@@ -322,13 +322,13 @@ end class
 	end func
 	
 	
-	+*func toInt(value: &int): bool
-		ret me.value.toInt(&value)
+	+*func toInt(existed: &bool): int
+		ret me.value.toInt(&existed)
 	end func
 	
 	
-	+*func toFloat(value: &float): bool
-		ret me.value.toFloat(&value)
+	+*func toFloat(existed: &bool): float
+		ret me.value.toFloat(&existed)
 	end func
 	
 	
@@ -365,8 +365,9 @@ end class
 	
 	+*func find(key: []char): @Json
 		var index: int
-		
-		if (!key.toInt(&index))
+		var existed: bool
+		do index :: key.toInt(&existed)
+		if (!existed)
 			var err: @JsonError :: #@JsonError
 			do err.addMessage(@errIndexType)
 			ret err
@@ -388,15 +389,15 @@ end class
 	end func
 	
 	
-	+*func toInt(value: &int): bool
-		do value :: me.len()
-		ret true
+	+*func toInt(existed: &bool): int
+		do existed :: true
+		ret me.len()
 	end func
 	
 	
-	+*func toFloat(value: &float): bool
-		do value :: me.len()$float
-		ret true
+	+*func toFloat(existed: &bool): float
+		do existed :: true
+		ret me.len()$float
 	end func
 	
 	
@@ -532,15 +533,15 @@ end class
 	end func
 	
 	
-	+*func toInt(value: &int): bool
-		do value :: me.len()
-		ret true
+	+*func toInt(existed: &bool): int
+		do existed :: true
+		ret me.len()
 	end func
 	
 	
-	+*func toFloat(value: &float): bool
-		do value :: me.len()$float
-		ret true
+	+*func toFloat(existed: &bool): float
+		do existed :: true
+		ret me.len()$float
 	end func
 	
 	

--- a/src/json.kn
+++ b/src/json.kn
@@ -824,7 +824,7 @@ end class
 		
 		var numeric: float
 		var existed: bool
-		numeric :: me.scanner.text().toFloat(&existed)
+		do numeric :: me.scanner.text().toFloat(&existed)
 		if (!existed)
 			throw @himeJsonInvalidDataFmt
 		end if

--- a/src/json.kn
+++ b/src/json.kn
@@ -524,7 +524,7 @@ end class
 			do err.addMessage(@errInvalidKey)
 			ret err
 		end if
-		ret me.value.get(key)
+		ret me.value.get(key, &)
 	end func
 	
 	
@@ -551,7 +551,7 @@ end class
 		
 		for index(0, ^keys - 1)
 			do text :~ "\"\{keys[index]}\":"
-			do text :~ me.value.get(keys[index]).dump()
+			do text :~ me.value.get(keys[index], &).dump()
 			if (index < ^keys - 1)
 				do text :~ ","
 			end if

--- a/src/json.kn
+++ b/src/json.kn
@@ -823,7 +823,9 @@ end class
 		end if
 		
 		var numeric: float
-		if (!me.scanner.text().toFloat(&numeric))
+		var existed: bool
+		numeric :: me.scanner.text().toFloat(&existed)
+		if (!existed)
 			throw @himeJsonInvalidDataFmt
 		end if
 		

--- a/test/main.kn
+++ b/test/main.kn
@@ -47,9 +47,17 @@ func main()
 		do @assertTrue((json.at("../") =& json2), "Json@at(3)")
 		do @assertTrue((json.at("a").type() = %jerr), "Json@at(4)")
 		do @assertTrue(!json.toBool(), "Json@toBool")
-		do @assertTrue(!json.toInt(&), "Json@toInt")
+
+		var existedToInt: bool
+		do json.toInt(&existedToInt)
+		do @assertTrue(!existedToInt, "Json@toInt")
+
 		do @assertTrue((json.toi() = 0), "Json@toi")
-		do @assertTrue(!json.toFloat(&), "Json@toFloat")
+
+		var existedToFloat: bool
+		do json.toFloat(&existedToFloat)
+		do @assertTrue(!existedToFloat, "Json@toFloat")
+
 		do @assertTrue(lib@same(json.tof(), 0.0), "Json@tof")
 		do @assertTrue((json.toStr() = ""), "Json@toStr")
 		do @assertTrue((json.toStrFmt("") = ""), "Json@toStrFmt")


### PR DESCRIPTION
### 変更点
- v.2018.6.17での以下一点
  - 16進数リテラルの構文を「16#」から「0x」に変更
- v.2018.11.17での以下の二点
  - dict.getの引数で存在の有無が取得できるように、引数を変更
  - []char.toInt、[]char.toFloatの引数をdict.getと同じ形に変更